### PR TITLE
Fix issue for not saving character to database after spawn in.

### DIFF
--- a/spawn/functions/finish.sqf
+++ b/spawn/functions/finish.sqf
@@ -18,4 +18,7 @@ fnc_usec_damageHandler = fnc_usec_damageHandlerOriginal;
 player_spawn_2 = player_spawn_2_original;
 
 dayz_slowCheck = [] spawn player_spawn_2;
+
+call player_forceSave;
+
 if (dayz_enableRules && (profileNamespace getVariable ["streamerMode",0] == 0)) then { dayz_rulesHandle = execVM "rules.sqf"; };


### PR DESCRIPTION
This fixes choosing a new character and spawning in and not saving to the database.
I found I was only getting saved to the database as a bare character till I issued this manual save which fixed my problem and saved my inventory/gear to the database.