### PR TITLE
Changing a string for specific translation for air spawn

### DIFF
--- a/spawn/dialogs.hpp
+++ b/spawn/dialogs.hpp
@@ -152,7 +152,7 @@ class HaloDialog
 		class HaloButtonAir
 		{
 			idc = -1;
-			text = $STR_DN_AIR;
+			text = $STR_ESS_AIR;
 			x = .402585 * safezoneW + safezoneX;
 			y = .533 * safezoneH + safezoneY;
 			w = .0743267 * safezoneW;

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -50,8 +50,8 @@
 			<German>Boden</German>
 		</Key>
 		<Key ID="STR_ESS_AIR">
-			<English>Air</English>
-			<German>Luft</German>
+			<English>Halo</English>
+			<German>Fallschirm</German>
 		</Key>
 	</Package>
 </Project>

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -50,7 +50,7 @@
 			<German>Boden</German>
 		</Key>
 		<Key ID="STR_ESS_AIR">
-			<English>Halo</English>
+			<English>HALO</English>
 			<German>Fallschirm</German>
 		</Key>
 	</Package>

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -49,5 +49,9 @@
 			<English>Ground</English>
 			<German>Boden</German>
 		</Key>
+		<Key ID="STR_ESS_AIR">
+			<English>Air</English>
+			<German>Luft</German>
+		</Key>
 	</Package>
 </Project>


### PR DESCRIPTION
Changed STR_DN_AIR to STR_ESS_AIR because of new stringtable and specific translations for ESS.